### PR TITLE
Remove duplicate hash key

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -653,12 +653,6 @@ module NewRelic
           :type => Boolean,
           :description => 'Enable or disable sequel instrumentation.'
         },
-        :disable_mongo => {
-          :default => false,
-          :public => true,
-          :type => Boolean,
-          :description => 'Enable or disable MongoDB instrumentation.'
-        },
         :'slow_sql.enabled' => {
           :default => DefaultSource.slow_sql_enabled,
           :public => true,


### PR DESCRIPTION
This is overwritten further below and is causing lots of warnings in all of our services.

Today, I was finally annoyed enough to fix this. ;)